### PR TITLE
Add basic Game of Cows Telegram bot

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /.env
 .idea/
 .venv/
+__pycache__/

--- a/handlers/handlers_admin.py
+++ b/handlers/handlers_admin.py
@@ -1,0 +1,82 @@
+from aiogram import Router, F
+from aiogram.filters import CommandStart, Command
+from aiogram.types import Message
+
+from config_data.config import load_config
+from keyboards.admin import admin_main_kb
+from keyboards.player import hours_kb
+from lexicon.lexicon_en import LEXICON_EN
+from services.services import create_game, list_games, start_day, end_day
+
+config = load_config()
+admin_router = Router()
+admin_router.message.filter(F.from_user.id.in_(config.tg_bot.admin_ids))
+
+
+@admin_router.message(CommandStart())
+async def admin_start(message: Message):
+    games = list_games()
+    text = LEXICON_EN['/start_admin']
+    if games:
+        text += '\n\n' + '\n'.join(f"{g.title} ({g.code})" for g in games)
+    await message.answer(text, reply_markup=admin_main_kb())
+
+
+@admin_router.message(Command('newgame'))
+async def process_newgame(message: Message):
+    parts = message.text.split(maxsplit=2)
+    if len(parts) < 3:
+        await message.answer('Usage: /newgame <title> <description>')
+        return
+    _, title, description = parts
+    game = create_game(message.from_user.id, title, description)
+    await message.answer(LEXICON_EN['game_created'].format(title=title, code=game.code))
+
+
+@admin_router.message(Command('start_day'))
+async def process_start_day(message: Message):
+    parts = message.text.split(maxsplit=1)
+    if len(parts) < 2:
+        await message.answer('Usage: /start_day <code>')
+        return
+    code = parts[1].strip()
+    day = start_day(code)
+    if not day:
+        await message.answer(LEXICON_EN['unknown_code'])
+        return
+    from services.services import GAMES
+    game = GAMES[code]
+    for pid in game.players:
+        await message.bot.send_message(pid, LEXICON_EN['day_prompt'].format(day=day),
+                                       reply_markup=hours_kb())
+    await message.answer(f'Day {day} started for game {code}')
+
+
+@admin_router.message(Command('end_day'))
+async def process_end_day(message: Message):
+    parts = message.text.split(maxsplit=1)
+    if len(parts) < 2:
+        await message.answer('Usage: /end_day <code>')
+        return
+    code = parts[1].strip()
+    result = end_day(code)
+    if not result:
+        await message.answer(LEXICON_EN['unknown_code'])
+        return
+    from services.services import GAMES
+    game = GAMES[code]
+    table_lines = [
+        f"{game.players[pid].nickname}: {info['hours']}h -> {info['coins']:.1f} coins"
+        for pid, info in result['results'].items()
+    ]
+    table = '\n'.join(table_lines)
+    for pid in result['results'].keys():
+        await message.bot.send_message(
+            pid,
+            LEXICON_EN['day_result'].format(
+                day=game.current_day,
+                level=result['field_level'],
+                table=table
+            )
+        )
+    await message.answer(f"Day {game.current_day} ended. Field level: {result['field_level']:.1f}")

--- a/handlers/handlers_other.py
+++ b/handlers/handlers_other.py
@@ -1,0 +1,9 @@
+from aiogram import Router
+from aiogram.types import Message
+
+other_router = Router()
+
+
+@other_router.message()
+async def other_message(message: Message):
+    await message.answer('Unknown command.')

--- a/handlers/handlers_player.py
+++ b/handlers/handlers_player.py
@@ -1,0 +1,43 @@
+from aiogram import Router, F
+from aiogram.filters import CommandStart, Command
+from aiogram.types import Message
+
+from config_data.config import load_config
+from lexicon.lexicon_en import LEXICON_EN
+from keyboards.player import hours_kb
+from services.services import join_game, get_game_by_player, submit_hours
+
+config = load_config()
+player_router = Router()
+player_router.message.filter(~F.from_user.id.in_(config.tg_bot.admin_ids))
+
+
+@player_router.message(CommandStart())
+async def player_start(message: Message):
+    await message.answer(LEXICON_EN['/start_player'])
+
+
+@player_router.message(Command('join'))
+async def join_game_cmd(message: Message):
+    parts = message.text.split(maxsplit=3)
+    if len(parts) < 4:
+        await message.answer('Usage: /join <code> <real_name> <nickname>')
+        return
+    _, code, real_name, nickname = parts
+    player = join_game(code, message.from_user.id, real_name, nickname)
+    if not player:
+        await message.answer(LEXICON_EN['unknown_code'])
+        return
+    await message.answer(LEXICON_EN['join_success'].format(title=get_game_by_player(message.from_user.id).title,
+                                                           nickname=nickname))
+
+
+@player_router.message(F.text.in_({str(i) for i in range(1, 11)}))
+async def receive_hours(message: Message):
+    game = get_game_by_player(message.from_user.id)
+    if not game or message.from_user.id not in game.awaiting_moves:
+        await message.answer(LEXICON_EN['not_in_game'])
+        return
+    hours = int(message.text)
+    submit_hours(game.code, message.from_user.id, hours)
+    await message.answer(LEXICON_EN['wait_others'])

--- a/keyboards/admin.py
+++ b/keyboards/admin.py
@@ -1,0 +1,9 @@
+from aiogram.types import ReplyKeyboardMarkup, KeyboardButton
+
+
+def admin_main_kb() -> ReplyKeyboardMarkup:
+    buttons = [
+        [KeyboardButton(text='/newgame')],
+        [KeyboardButton(text='/start_day'), KeyboardButton(text='/end_day')],
+    ]
+    return ReplyKeyboardMarkup(keyboard=buttons, resize_keyboard=True)

--- a/keyboards/player.py
+++ b/keyboards/player.py
@@ -1,0 +1,9 @@
+from aiogram.types import ReplyKeyboardMarkup, KeyboardButton
+
+
+def hours_kb() -> ReplyKeyboardMarkup:
+    keyboard = [
+        [KeyboardButton(text=str(i)) for i in range(1, 6)],
+        [KeyboardButton(text=str(i)) for i in range(6, 11)]
+    ]
+    return ReplyKeyboardMarkup(keyboard=keyboard, resize_keyboard=True, one_time_keyboard=True)

--- a/keyboards/set_menu.py
+++ b/keyboards/set_menu.py
@@ -1,0 +1,11 @@
+from aiogram import Bot
+from aiogram.types import BotCommand
+
+
+async def set_main_menu(bot: Bot) -> None:
+    commands = [
+        BotCommand(command='/start', description='Start bot'),
+        BotCommand(command='/newgame', description='Create new game'),
+        BotCommand(command='/join', description='Join a game'),
+    ]
+    await bot.set_my_commands(commands)

--- a/lexicon/lexicon_en.py
+++ b/lexicon/lexicon_en.py
@@ -1,3 +1,11 @@
 LEXICON_EN: dict[str, str] = {
-    "/about": "Hello! I am your personal assistant bot. Test",
+    '/start_admin': 'Welcome, admin! Use /newgame <title> <description> to create a game.',
+    '/start_player': 'Welcome! Use /join <code> <real_name> <nickname> to join a game.',
+    'game_created': 'Game "{title}" created. Code: {code}',
+    'join_success': 'You joined the game "{title}" as {nickname}.',
+    'unknown_code': 'Unknown game code.',
+    'day_prompt': 'Day {day}. Send grazing hours (1-10).',
+    'wait_others': 'Your choice is saved. Waiting for others...',
+    'day_result': 'Day {day} finished. Field level: {level:.1f}\n{table}',
+    'not_in_game': 'You are not participating in a game.',
 }

--- a/main.py
+++ b/main.py
@@ -4,7 +4,9 @@ import logging
 from aiogram import Bot, Dispatcher
 from config_data.config import Config, load_config
 from handlers.handlers_other import other_router
-from handlers.handlers_player import user_router
+from handlers.handlers_player import player_router
+from handlers.handlers_admin import admin_router
+from keyboards.set_menu import set_main_menu
 
 # Настраиваем базовую конфигурацию логирования
 logging.basicConfig(
@@ -26,9 +28,11 @@ async def main() -> None:
     # Инициализируем бот и диспетчер
     bot = Bot(token=config.tg_bot.token)
     dp = Dispatcher()
+    await set_main_menu(bot)
 
     # Регистрируем роутеры в диспетчере
-    dp.include_router(user_router)
+    dp.include_router(admin_router)
+    dp.include_router(player_router)
     dp.include_router(other_router)
 
     # Здесь будем регистрировать миддлвари

--- a/services/services.py
+++ b/services/services.py
@@ -1,0 +1,137 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Dict, List, Optional
+import random
+import string
+import time
+
+# ---------- Data models ----------
+
+
+@dataclass
+class Player:
+    tg_id: int
+    real_name: str
+    nickname: str
+    coins: float = 0.0
+    total_hours: int = 0
+    moves: List[int] = field(default_factory=list)
+
+    @property
+    def average_hours(self) -> float:
+        if not self.moves:
+            return 0.0
+        return self.total_hours / len(self.moves)
+
+
+@dataclass
+class Game:
+    code: str
+    title: str
+    description: str
+    decay: float
+    recovery: float
+    host_id: int
+    field_level: float = 100.0
+    created_at: float = field(default_factory=time.time)
+    players: Dict[int, Player] = field(default_factory=dict)
+    current_day: int = 0
+    awaiting_moves: Dict[int, Optional[int]] = field(default_factory=dict)
+
+
+# In-memory storage for games
+GAMES: Dict[str, Game] = {}
+
+
+# ---------- Utility functions ----------
+
+def generate_code() -> str:
+    """Generate a unique 8 digit code for a game."""
+    while True:
+        code = ''.join(random.choices(string.digits, k=8))
+        if code not in GAMES:
+            return code
+
+
+def list_games() -> List[Game]:
+    return list(GAMES.values())
+
+
+def create_game(host_id: int, title: str, description: str,
+                decay: float = 2.0, recovery: float = 1.0) -> Game:
+    code = generate_code()
+    game = Game(code=code,
+                title=title,
+                description=description,
+                decay=decay,
+                recovery=recovery,
+                host_id=host_id)
+    GAMES[code] = game
+    return game
+
+
+def join_game(code: str, tg_id: int, real_name: str, nickname: str) -> Optional[Player]:
+    game = GAMES.get(code)
+    if not game:
+        return None
+    if tg_id in game.players:
+        return game.players[tg_id]
+    player = Player(tg_id=tg_id, real_name=real_name, nickname=nickname)
+    game.players[tg_id] = player
+    return player
+
+
+def get_game_by_player(tg_id: int) -> Optional[Game]:
+    for game in GAMES.values():
+        if tg_id in game.players:
+            return game
+    return None
+
+
+def start_day(code: str) -> Optional[int]:
+    game = GAMES.get(code)
+    if not game:
+        return None
+    game.current_day += 1
+    game.awaiting_moves = {pid: None for pid in game.players.keys()}
+    return game.current_day
+
+
+def submit_hours(code: str, player_id: int, hours: int) -> bool:
+    game = GAMES.get(code)
+    if not game or player_id not in game.awaiting_moves:
+        return False
+    game.awaiting_moves[player_id] = hours
+    return True
+
+
+def end_day(code: str):
+    game = GAMES.get(code)
+    if not game:
+        return None
+    if not game.awaiting_moves:
+        return None
+    total_hours = sum(h for h in game.awaiting_moves.values() if h is not None)
+    num_players = len(game.awaiting_moves)
+    avg_hours = total_hours / num_players if num_players else 0
+    if avg_hours > 5:
+        game.field_level = max(0.0, game.field_level - (avg_hours - 5) * game.decay)
+    elif avg_hours < 5:
+        game.field_level = min(100.0, game.field_level + (5 - avg_hours) * game.recovery)
+    results = {}
+    for pid, hours in game.awaiting_moves.items():
+        if hours is None:
+            continue
+        player = game.players[pid]
+        coins = hours * game.field_level
+        player.coins += coins
+        player.total_hours += hours
+        player.moves.append(hours)
+        results[pid] = {"hours": hours, "coins": coins}
+    game.awaiting_moves = {}
+    return {"results": results, "field_level": game.field_level, "avg_hours": avg_hours}
+
+
+def finish_game(code: str) -> Optional[Game]:
+    return GAMES.pop(code, None)


### PR DESCRIPTION
## Summary
- implement in-memory game models and service functions
- add admin and player handlers with keyboards
- configure bot startup and menu

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_6897249a6b40833385305b8a57ca3c53