### PR TITLE
Add basic game creation FSM and admin game list

### DIFF
--- a/keyboards/admin_inline.py
+++ b/keyboards/admin_inline.py
@@ -1,0 +1,14 @@
+from aiogram.types import InlineKeyboardMarkup, InlineKeyboardButton
+
+
+def games_list_kb(games) -> InlineKeyboardMarkup:
+    buttons = [[InlineKeyboardButton(text=g.title, callback_data=f"game_{g.id}")]
+               for g in games]
+    buttons.append([InlineKeyboardButton(text="New game", callback_data="new_game")])
+    return InlineKeyboardMarkup(inline_keyboard=buttons)
+
+
+def back_to_games_kb() -> InlineKeyboardMarkup:
+    return InlineKeyboardMarkup(inline_keyboard=[
+        [InlineKeyboardButton(text="Back", callback_data="back_to_games")]
+    ])

--- a/services/game_creation.py
+++ b/services/game_creation.py
@@ -1,0 +1,110 @@
+from __future__ import annotations
+
+import sqlite3
+import time
+from dataclasses import dataclass
+from typing import List
+
+from aiogram.fsm.state import State, StatesGroup
+
+DB_PATH = 'games.db'
+
+
+def _get_conn():
+    conn = sqlite3.connect(DB_PATH)
+    conn.row_factory = sqlite3.Row
+    return conn
+
+
+def init_db():
+    with _get_conn() as conn:
+        conn.execute(
+            """
+            CREATE TABLE IF NOT EXISTS games (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                title TEXT NOT NULL,
+                description TEXT NOT NULL,
+                created_at INTEGER NOT NULL,
+                creator_id INTEGER NOT NULL,
+                is_active INTEGER NOT NULL DEFAULT 1,
+                days_in_game INTEGER NOT NULL DEFAULT 0,
+                code TEXT NOT NULL UNIQUE
+            )
+            """
+        )
+
+
+init_db()
+
+
+class GameCreation(StatesGroup):
+    """States for creating a new game."""
+
+    title = State()
+    description = State()
+
+
+@dataclass
+class GameInfo:
+    id: int
+    title: str
+    description: str
+    created_at: int
+    creator_id: int
+    is_active: bool
+    days_in_game: int
+    code: str
+
+
+def create_game_record(creator_id: int, title: str, description: str, code: str) -> int:
+    """Insert game into DB and return row id."""
+    with _get_conn() as conn:
+        cur = conn.execute(
+            "INSERT INTO games(title, description, created_at, creator_id, is_active, days_in_game, code) "
+            "VALUES(?, ?, ?, ?, 1, 0, ?)",
+            (title, description, int(time.time()), creator_id, code),
+        )
+        return cur.lastrowid
+
+
+def list_admin_games(admin_id: int) -> List[GameInfo]:
+    with _get_conn() as conn:
+        rows = conn.execute(
+            "SELECT * FROM games WHERE creator_id=? AND is_active=0 ORDER BY created_at DESC",
+            (admin_id,),
+        ).fetchall()
+    return [GameInfo(**dict(r)) for r in rows]
+
+
+def get_game_info(game_id: int) -> GameInfo | None:
+    with _get_conn() as conn:
+        row = conn.execute("SELECT * FROM games WHERE id=?", (game_id,)).fetchone()
+    return GameInfo(**dict(row)) if row else None
+from aiogram.types import Message
+from aiogram.fsm.context import FSMContext
+
+from services.services import generate_code, create_game
+
+
+async def start_creation(message: Message, state: FSMContext) -> None:
+    """Start the game creation dialog."""
+    await state.set_state(GameCreation.title)
+    await message.answer("Enter game title:")
+
+
+async def set_title(message: Message, state: FSMContext) -> None:
+    await state.update_data(title=message.text.strip())
+    await state.set_state(GameCreation.description)
+    await message.answer("Enter game description:")
+
+
+async def set_description(message: Message, state: FSMContext) -> None:
+    data = await state.get_data()
+    title = data.get("title")
+    description = message.text.strip()
+    code = generate_code()
+    # save to in-memory game structure
+    create_game(message.from_user.id, title, description)
+    create_game_record(message.from_user.id, title, description, code)
+    await state.clear()
+    await message.answer(f"Game '{title}' created with code {code}")


### PR DESCRIPTION
## Summary
- add SQLite-backed game creation service with FSM helpers
- show admin inline list of finished games and allow creating new games
- provide callbacks and keyboards for navigating games

## Testing
- `python -m py_compile handlers/handlers_admin.py services/game_creation.py keyboards/admin_inline.py`


------
https://chatgpt.com/codex/tasks/task_e_68973a9bba788333ba163cac15ac88b2