### PR TITLE
Add admin game creation via SQLAlchemy

### DIFF
--- a/handlers/handlers_admin.py
+++ b/handlers/handlers_admin.py
@@ -1,36 +1,61 @@
 from aiogram import Router, F
 from aiogram.filters import CommandStart, Command
-from aiogram.types import Message
+from aiogram.fsm.context import FSMContext
+from aiogram.fsm.state import State, StatesGroup
+from aiogram.types import Message, CallbackQuery
 
 from config_data.config import load_config
 from keyboards.admin import admin_main_kb
 from keyboards.player import hours_kb
 from lexicon.lexicon_en import LEXICON_EN
-from services.services import create_game, list_games, start_day, end_day
+from services.game_creation import create_game_db, finished_games_count
+from services.services import create_game, start_day, end_day
 
 config = load_config()
 admin_router = Router()
 admin_router.message.filter(F.from_user.id.in_(config.tg_bot.admin_ids))
+admin_router.callback_query.filter(F.from_user.id.in_(config.tg_bot.admin_ids))
 
 
 @admin_router.message(CommandStart())
 async def admin_start(message: Message):
-    games = list_games()
-    text = LEXICON_EN['/start_admin']
-    if games:
-        text += '\n\n' + '\n'.join(f"{g.title} ({g.code})" for g in games)
+    count = finished_games_count()
+    text = LEXICON_EN['admin_menu'].format(count=count)
     await message.answer(text, reply_markup=admin_main_kb())
 
 
-@admin_router.message(Command('newgame'))
-async def process_newgame(message: Message):
-    parts = message.text.split(maxsplit=2)
-    if len(parts) < 3:
-        await message.answer('Usage: /newgame <title> <description>')
-        return
-    _, title, description = parts
-    game = create_game(message.from_user.id, title, description)
-    await message.answer(LEXICON_EN['game_created'].format(title=title, code=game.code))
+class NewGame(StatesGroup):
+    title = State()
+    description = State()
+
+
+@admin_router.callback_query(F.data == 'new_game')
+async def new_game_callback(callback: CallbackQuery, state: FSMContext):
+    await callback.message.edit_text(LEXICON_EN['ask_title'])
+    await state.set_state(NewGame.title)
+
+
+@admin_router.message(NewGame.title)
+async def process_title(message: Message, state: FSMContext):
+    await state.update_data(title=message.text)
+    await message.answer(LEXICON_EN['ask_description'])
+    await state.set_state(NewGame.description)
+
+
+@admin_router.message(NewGame.description)
+async def process_description(message: Message, state: FSMContext):
+    data = await state.get_data()
+    title = data['title']
+    description = message.text
+    db_game = create_game_db(title, description, message.from_user.id)
+    create_game(message.from_user.id, title, description, code=db_game.registration_code)
+    await message.answer(LEXICON_EN['game_created_code'].format(title=title, code=db_game.registration_code))
+    await state.clear()
+
+
+@admin_router.callback_query(F.data == 'finished_games')
+async def show_finished_games(callback: CallbackQuery):
+    await callback.answer(LEXICON_EN['feature_not_implemented'], show_alert=True)
 
 
 @admin_router.message(Command('start_day'))

--- a/keyboards/admin.py
+++ b/keyboards/admin.py
@@ -1,9 +1,12 @@
-from aiogram.types import ReplyKeyboardMarkup, KeyboardButton
+from aiogram.types import InlineKeyboardButton, InlineKeyboardMarkup
+
+from lexicon.lexicon_en import LEXICON_EN
 
 
-def admin_main_kb() -> ReplyKeyboardMarkup:
+def admin_main_kb() -> InlineKeyboardMarkup:
+    """Main menu keyboard for admin."""
     buttons = [
-        [KeyboardButton(text='/newgame')],
-        [KeyboardButton(text='/start_day'), KeyboardButton(text='/end_day')],
+        [InlineKeyboardButton(text=LEXICON_EN['btn_new_game'], callback_data='new_game')],
+        [InlineKeyboardButton(text=LEXICON_EN['btn_finished_games'], callback_data='finished_games')],
     ]
-    return ReplyKeyboardMarkup(keyboard=buttons, resize_keyboard=True)
+    return InlineKeyboardMarkup(inline_keyboard=buttons)

--- a/lexicon/lexicon_en.py
+++ b/lexicon/lexicon_en.py
@@ -8,4 +8,12 @@ LEXICON_EN: dict[str, str] = {
     'wait_others': 'Your choice is saved. Waiting for others...',
     'day_result': 'Day {day} finished. Field level: {level:.1f}\n{table}',
     'not_in_game': 'You are not participating in a game.',
+    # --- Admin course creation ---
+    'admin_menu': 'Finished games: {count}',
+    'btn_new_game': 'New game',
+    'btn_finished_games': 'Show finished games',
+    'ask_title': 'Please enter the game title.',
+    'ask_description': 'Please enter the game description.',
+    'game_created_code': 'Game {title} registration code: {code}',
+    'feature_not_implemented': 'This feature is not implemented yet.',
 }

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 aiogram==3.10.0
 environs==11.0.0
+SQLAlchemy==2.0.29

--- a/services/database.py
+++ b/services/database.py
@@ -1,0 +1,6 @@
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker, declarative_base
+
+engine = create_engine('sqlite:///bot.db')
+SessionLocal = sessionmaker(bind=engine)
+Base = declarative_base()

--- a/services/game_creation.py
+++ b/services/game_creation.py
@@ -1,0 +1,34 @@
+import random
+import string
+
+from sqlalchemy.orm import Session
+
+from .database import SessionLocal
+from .models import GameModel
+
+
+def generate_registration_code(length: int = 8) -> str:
+    """Generate a random registration code."""
+    return ''.join(random.choices(string.ascii_uppercase + string.digits, k=length))
+
+
+def create_game_db(title: str, description: str, host_id: int) -> GameModel:
+    """Create a game in database and return model instance."""
+    code = generate_registration_code()
+    with SessionLocal() as session:
+        game = GameModel(
+            title=title,
+            description=description,
+            host_telegram_id=host_id,
+            registration_code=code,
+            is_active=True,
+        )
+        session.add(game)
+        session.commit()
+        session.refresh(game)
+        return game
+
+
+def finished_games_count() -> int:
+    with SessionLocal() as session:
+        return session.query(GameModel).filter_by(is_active=False).count()

--- a/services/models.py
+++ b/services/models.py
@@ -1,0 +1,21 @@
+from datetime import datetime
+from sqlalchemy import Integer, String, Boolean, DateTime
+from sqlalchemy.orm import Mapped, mapped_column
+
+from .database import Base, engine
+
+
+class GameModel(Base):
+    __tablename__ = 'games'
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True)
+    title: Mapped[str] = mapped_column(String)
+    description: Mapped[str] = mapped_column(String)
+    created_at: Mapped[datetime] = mapped_column(DateTime, default=datetime.utcnow)
+    host_telegram_id: Mapped[int] = mapped_column(Integer)
+    played_days: Mapped[int] = mapped_column(Integer, nullable=True)
+    registration_code: Mapped[str] = mapped_column(String, unique=True, index=True)
+    is_active: Mapped[bool] = mapped_column(Boolean, default=True)
+
+
+Base.metadata.create_all(bind=engine)

--- a/services/services.py
+++ b/services/services.py
@@ -59,8 +59,10 @@ def list_games() -> List[Game]:
 
 
 def create_game(host_id: int, title: str, description: str,
-                decay: float = 2.0, recovery: float = 1.0) -> Game:
-    code = generate_code()
+                decay: float = 2.0, recovery: float = 1.0,
+                code: str | None = None) -> Game:
+    if code is None:
+        code = generate_code()
     game = Game(code=code,
                 title=title,
                 description=description,


### PR DESCRIPTION
## Summary
- add SQLAlchemy models and helpers to persist games
- implement admin menu with inline keyboard and FSM-driven game creation
- extend lexicon with English texts for game creation flow

## Testing
- `python -m py_compile handlers/handlers_admin.py keyboards/admin.py lexicon/lexicon_en.py services/services.py services/database.py services/models.py services/game_creation.py`
- `pip install SQLAlchemy==2.0.29` *(failed: Could not connect to proxy / no matching distribution)*

------
https://chatgpt.com/codex/tasks/task_e_68974d054dd88333b1b50a36a44186d6