### PR TITLE
Add course creation flow for admins

### DIFF
--- a/database/database.py
+++ b/database/database.py
@@ -1,0 +1,20 @@
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+
+from .models import Base
+
+DATABASE_URL = "sqlite+aiosqlite:///database.db"
+
+engine = create_async_engine(DATABASE_URL, echo=False)
+async_session_maker = async_sessionmaker(engine, expire_on_commit=False)
+
+
+async def init_db() -> None:
+    """Create database tables."""
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+
+
+async def get_session() -> AsyncSession:
+    """Provide a transactional scope around a series of operations."""
+    async with async_session_maker() as session:
+        yield session

--- a/database/models.py
+++ b/database/models.py
@@ -1,0 +1,25 @@
+from __future__ import annotations
+
+from datetime import datetime
+
+from sqlalchemy import Boolean, DateTime, Integer, String
+from sqlalchemy.orm import DeclarativeBase, Mapped, mapped_column
+
+
+class Base(DeclarativeBase):
+    """Base declarative class for all models."""
+
+
+class Course(Base):
+    """Model representing a game course."""
+
+    __tablename__ = "courses"
+
+    id: Mapped[int] = mapped_column(primary_key=True, autoincrement=True)
+    name: Mapped[str] = mapped_column(String(100))
+    description: Mapped[str] = mapped_column(String(255))
+    created_at: Mapped[datetime] = mapped_column(DateTime, default=datetime.utcnow)
+    host_telegram_id: Mapped[int] = mapped_column(Integer)
+    days_played: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    registration_code: Mapped[str] = mapped_column(String(16), unique=True)
+    is_active: Mapped[bool] = mapped_column(Boolean, default=True)

--- a/handlers/handlers_host.py
+++ b/handlers/handlers_host.py
@@ -1,0 +1,63 @@
+from aiogram import F, Router
+from aiogram.filters import CommandStart
+from aiogram.fsm.context import FSMContext
+from aiogram.fsm.state import State, StatesGroup
+from aiogram.types import CallbackQuery, Message
+
+from config_data.config import load_config
+from database.database import async_session_maker
+from lexicon.lexicon_en import LEXICON_EN
+from keyboards.admin import admin_main_keyboard
+from services.course_creation import create_course
+
+config = load_config()
+HOST_IDS = config.tg_bot.host_ids
+
+host_router = Router()
+
+
+class NewCourse(StatesGroup):
+    waiting_for_name = State()
+    waiting_for_description = State()
+    waiting_for_players = State()
+
+
+@host_router.message(CommandStart(), F.from_user.id.in_(HOST_IDS))
+async def host_start(message: Message) -> None:
+    await message.answer(
+        LEXICON_EN["host_menu_inactive"].format(count=0),
+        reply_markup=admin_main_keyboard(),
+    )
+
+
+@host_router.callback_query(F.data == "new_course")
+async def process_new_course(callback: CallbackQuery, state: FSMContext) -> None:
+    await callback.message.edit_reply_markup()
+    await callback.message.answer(LEXICON_EN["ask_course_name"])
+    await state.set_state(NewCourse.waiting_for_name)
+
+
+@host_router.message(NewCourse.waiting_for_name, F.text)
+async def process_course_name(message: Message, state: FSMContext) -> None:
+    await state.update_data(name=message.text)
+    await message.answer(LEXICON_EN["ask_course_description"])
+    await state.set_state(NewCourse.waiting_for_description)
+
+
+@host_router.message(NewCourse.waiting_for_description, F.text)
+async def process_course_description(message: Message, state: FSMContext) -> None:
+    data = await state.get_data()
+    async with async_session_maker() as session:
+        course = await create_course(
+            session=session,
+            host_id=message.from_user.id,
+            name=data["name"],
+            description=message.text,
+        )
+    await state.update_data(course_id=course.id, host_id=message.from_user.id)
+    await state.set_state(NewCourse.waiting_for_players)
+    await message.answer(
+        LEXICON_EN["course_created"].format(
+            name=course.name, code=course.registration_code
+        )
+    )

--- a/handlers/handlers_other.py
+++ b/handlers/handlers_other.py
@@ -1,0 +1,18 @@
+from aiogram import Router
+from aiogram.filters import CommandStart
+from aiogram.types import Message
+
+from config_data.config import load_config
+from lexicon.lexicon_en import LEXICON_EN
+
+config = load_config()
+HOST_IDS = config.tg_bot.host_ids
+
+other_router = Router()
+
+
+@other_router.message(CommandStart())
+async def user_start(message: Message) -> None:
+    if message.from_user.id in HOST_IDS:
+        return
+    await message.answer(LEXICON_EN["ask_registration_code"])

--- a/handlers/handlers_player.py
+++ b/handlers/handlers_player.py
@@ -1,0 +1,3 @@
+from aiogram import Router
+
+player_router = Router()

--- a/keyboards/admin.py
+++ b/keyboards/admin.py
@@ -1,0 +1,21 @@
+from aiogram.types import InlineKeyboardButton, InlineKeyboardMarkup
+
+from lexicon.lexicon_en import LEXICON_EN
+
+
+def admin_main_keyboard() -> InlineKeyboardMarkup:
+    return InlineKeyboardMarkup(
+        inline_keyboard=[
+            [
+                InlineKeyboardButton(
+                    text=LEXICON_EN["new_course_button"], callback_data="new_course"
+                )
+            ],
+            [
+                InlineKeyboardButton(
+                    text=LEXICON_EN["show_finished_courses_button"],
+                    callback_data="show_finished_courses",
+                )
+            ],
+        ]
+    )

--- a/lexicon/lexicon_en.py
+++ b/lexicon/lexicon_en.py
@@ -1,3 +1,10 @@
 LEXICON_EN: dict[str, str] = {
     "/about": "Hello! I am your personal assistant bot.",
+    "host_menu_inactive": "Completed courses: {count}",
+    "new_course_button": "New course",
+    "show_finished_courses_button": "Show finished courses",
+    "ask_course_name": "Please enter the course name.",
+    "ask_course_description": "Please enter the course description.",
+    "course_created": "Course '{name}' registration code: {code}",
+    "ask_registration_code": "To join a course, send the registration code.",
 }

--- a/main.py
+++ b/main.py
@@ -3,6 +3,7 @@ import logging
 
 from aiogram import Bot, Dispatcher
 from config_data.config import Config, load_config
+from database.database import init_db
 from handlers.handlers_other import other_router
 from handlers.handlers_player import player_router
 from handlers.handlers_host import host_router
@@ -27,6 +28,9 @@ async def main() -> None:
     # Инициализируем бот и диспетчер
     bot = Bot(token=config.tg_bot.token)
     dp = Dispatcher()
+
+    # Инициализируем базу данных
+    await init_db()
 
     # Регистрируем роутеры в диспетчере
     dp.include_router(host_router)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 aiogram==3.10.0
 environs==11.0.0
 SQLAlchemy==2.0.29
+aiosqlite==0.19.0

--- a/services/course_creation.py
+++ b/services/course_creation.py
@@ -1,0 +1,27 @@
+import secrets
+from datetime import datetime
+
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from database.models import Course
+
+
+async def create_course(
+    session: AsyncSession,
+    host_id: int,
+    name: str,
+    description: str,
+) -> Course:
+    """Create a new course and persist it to the database."""
+    registration_code = secrets.token_hex(4)
+    course = Course(
+        name=name,
+        description=description,
+        host_telegram_id=host_id,
+        registration_code=registration_code,
+        created_at=datetime.utcnow(),
+    )
+    session.add(course)
+    await session.commit()
+    await session.refresh(course)
+    return course


### PR DESCRIPTION
## Summary
- add Course model and async database helpers
- implement admin FSM to create courses with registration code
- provide admin keyboard and English lexicon entries
- initialize database on startup

## Testing
- `python -m py_compile database/models.py database/database.py services/course_creation.py handlers/handlers_host.py handlers/handlers_other.py handlers/handlers_player.py keyboards/admin.py lexicon/lexicon_en.py main.py`
- `pytest`
- `pip install -r requirements.txt` *(failed: Could not find aiosqlite due to 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6897520281c48333a00b05c77d992b0a